### PR TITLE
Make links to 10.x versions more visible for the users

### DIFF
--- a/templates/_content_download_download.ftl
+++ b/templates/_content_download_download.ftl
@@ -7,12 +7,14 @@
 <#macro layout>
     <@parent.layout>
         <#assign pom = data.get('pom.yml')>
-        <div class="sect1">
-            <h2 id="_new_home">Drools has a new home at Apache KIE (Incubating) </h2>
-            <div class="sectionbody">
-                <p>For the latest information, code and releases take a look at the new project home at <a href="https://kie.apache.org/">kie.apache.org</a></p>
-            </div>
+        <div class="alert alert-info alert-dismissible" role="alert" id="release-version-alert">
+            <i class="fas fa-info-circle"></i>
+            Drools has a new home at Apache KIE (Incubating)
+            <br/><a class="alert-link"
+                    href="https://kie.apache.org/">For the latest information, code and releases take a look at the new project home at kie.apache.org</a>
+            <button class="btn-close" data-bs-dismiss="alert" type="button" aria-label="Close"></button>
         </div>
+        <br/>
         <div class="sect1">
             <h2 id="_10x">10.x versions:</h2>
             <div class="sectionbody">
@@ -20,6 +22,8 @@
                     <ul>
                         <li>
                             <p><a href="https://kie.apache.org/docs/start/download/">Downloads</a></p>
+                        </li>
+                        <li>
                             <p><a href="https://kie.apache.org/docs/documentation/">Documentation</a></p>
                         </li>
                     </ul>

--- a/templates/_content_download_download.ftl
+++ b/templates/_content_download_download.ftl
@@ -14,7 +14,21 @@
             </div>
         </div>
         <div class="sect1">
-            <h2 id="_latest_final_version_pom_latestfinal_version">Latest final version: ${pom.latestFinal.version}</h2>
+            <h2 id="_10x">10.x versions:</h2>
+            <div class="sectionbody">
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p><a href="https://kie.apache.org/docs/start/download/">Downloads</a></p>
+                            <p><a href="https://kie.apache.org/docs/documentation/">Documentation</a></p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <br/>
+        <div class="sect1">
+            <h2 id="_latest_final_version_pom_latestfinal_version">Latest 8.x version: ${pom.latestFinal.version}</h2>
             <div class="sectionbody">
                 <div class="ulist">
                     <ul>

--- a/templates/_content_learn_documentation.ftl
+++ b/templates/_content_learn_documentation.ftl
@@ -7,37 +7,31 @@
     <@parent.layout>
         <#assign pom = data.get('pom.yml')>
 
-        <div class="sect1">
-            <h2 id="_new_home">Drools has a new home at Apache KIE (Incubating) </h2>
-            <div class="sectionbody">
-                <p>For the latest information, code and releases take a look at the new project home at <a href="https://kie.apache.org/">kie.apache.org</a></p>
-            </div>
+        <div class="alert alert-info alert-dismissible" role="alert" id="release-version-alert">
+            <i class="fas fa-info-circle"></i>
+            Drools has a new home at Apache KIE (Incubating)
+            <br/><a class="alert-link"
+               href="https://kie.apache.org/">For the latest information, code and releases take a look at the new project home at kie.apache.org</a>
+            <button class="btn-close" data-bs-dismiss="alert" type="button" aria-label="Close"></button>
         </div>
+        <br/>
         <div class="sect1">
             <h2 id="_latest_10_x_releases">10.x releases</h2>
             <div class="sectionbody">
                 <div class="ulist">
                     <ul>
                         <li>
-                            <p><strong>Documentation for Drools 10.1.0</strong></p>
-                            <div class="ulist">
-                                <ul>
-                                    <li>
-                                        <p><span class="image"><img src="documentation.png" alt="documentation"></span>
-                                            <strong>Reference manual Drools 10.1.0</strong>:
-                                            <a href="https://kie.apache.org/docs/10.1.x/drools">Drools User Guide</a></p>
-                                    </li>
-                                    <li>
-                                        <p><strong>NB!
-                                                There might be newer versions!</strong>:
-                                            <a href="https://kie.apache.org/docs/10.1.x/drools">List of all 10.x versions</a></p>
-                                    </li>
-                                    <li>
-                                        <p>Container images:
-                                            <a href="https://kie.apache.org/docs/start/download#container-images">10.x versions</a></p>
-                                    </li>
-                                </ul>
-                            </div>
+                            <p><span class="image"><img src="documentation.png" alt="documentation"></span>
+                                <strong>Reference manual Drools 10.1.0</strong>:
+                                <a href="https://kie.apache.org/docs/10.1.x/drools">Drools User Guide</a></p>
+                        </li>
+                        <li>
+                            <p><strong>There might be newer versions</strong>:
+                                <a href="https://kie.apache.org/docs/10.1.x/drools">List of all 10.x versions</a></p>
+                        </li>
+                        <li>
+                            <p>Container images:
+                                <a href="https://kie.apache.org/docs/start/download#container-images">10.x versions</a></p>
                         </li>
                     </ul>
                 </div>

--- a/templates/_content_learn_documentation.ftl
+++ b/templates/_content_learn_documentation.ftl
@@ -14,7 +14,38 @@
             </div>
         </div>
         <div class="sect1">
-            <h2 id="_final_releases">Final releases</h2>
+            <h2 id="_latest_10_x_releases">10.x releases</h2>
+            <div class="sectionbody">
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p><strong>Documentation for Drools 10.1.0</strong></p>
+                            <div class="ulist">
+                                <ul>
+                                    <li>
+                                        <p><span class="image"><img src="documentation.png" alt="documentation"></span>
+                                            <strong>Reference manual Drools 10.1.0</strong>:
+                                            <a href="https://kie.apache.org/docs/10.1.x/drools">Drools User Guide</a></p>
+                                    </li>
+                                    <li>
+                                        <p><strong>NB!
+                                                There might be newer versions!</strong>:
+                                            <a href="https://kie.apache.org/docs/10.1.x/drools">List of all 10.x versions</a></p>
+                                    </li>
+                                    <li>
+                                        <p>Container images:
+                                            <a href="https://kie.apache.org/docs/start/download#container-images">10.x versions</a></p>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+                <hr>
+            </div>
+        </div>
+        <div class="sect1">
+            <h2 id="_final_releases">Latest 8.x releases</h2>
             <div class="sectionbody">
                 <div class="ulist">
                     <ul>

--- a/templates/index.ftl
+++ b/templates/index.ftl
@@ -12,11 +12,12 @@
     googleWebmasterToolsVerification=true>
         <div class="alert alert-info alert-dismissible" role="alert" id="release-version-alert">
             <i class="fas fa-info-circle"></i>
-            ${pom.latestFinal.releaseDate?date?string.iso}:
+            2025-07-10:
             <a class="alert-link"
-               href="https://kie.apache.org/blog/kie_10_0_0_release">Drools 10.0.0.Final has been released by KIE Apache (Incubating) community.</a>
+               href="https://kie.apache.org/blog/kie_10_1_0_release">Drools 10.1.0 has been released by KIE Apache (Incubating) community.</a>
             <button class="btn-close" data-bs-dismiss="alert" type="button" aria-label="Close"></button>
         </div>
+        <br/>
         <div class="row">
             <div class="col-md-8" style="margin-top: -17px;margin-bottom: 20px">
                 <p>

--- a/templates/macros.ftl
+++ b/templates/macros.ftl
@@ -22,10 +22,6 @@
                     <img alt="Download" src="/download/download.png">
                     <div>
                         <span>Try ${config.title}</span><br>
-                        <span class="small">${pom.latest.version}</span>
-                    </div>
-                    <div class="small">
-                        ${pom.latest.releaseDate?string("EEE d MMMM yyyy")}
                     </div>
                 </a>
             </#if>

--- a/templates/macros.ftl
+++ b/templates/macros.ftl
@@ -12,7 +12,6 @@
                     <img alt="Download" src="/download/download.png">
                     <div>
                         <span>Try ${config.title}</span><br>
-                        <span class="small">${pom.latestFinal.version}</span>
                     </div>
                 </a>
             </#if>
@@ -247,7 +246,6 @@
                 <img alt="Download" src="${content.rootpath}download/download.png">
                 <div>
                     <span>Try Drools</span><br/>
-                    <span class="small">Download ${pom.latestFinal.version}</span>
                 </div>
             </a>
         </div>
@@ -270,11 +268,11 @@
     <div class="card border-0">
         <div class="card-body">
             <a class="btn btn-lg btn-light w-100"
-               href="${pom.latestFinal.documentationHtmlSingle}#quickStart">
+               href="https://kie.apache.org/docs/10.1.x/drools/drools/introduction/index.html">
                 <img alt="Documentation" src="${content.rootpath}learn/documentation.png">
                 <div>
                     <span>Get started</span><br/>
-                    <span class="small">User guide ${pom.latestFinal.version}</span>
+                    <span class="small">User guide 10.1.0</span>
                 </div>
             </a>
         </div>


### PR DESCRIPTION
When a user quickly scans the drools.org web page, it might go unnoticed for the user that 10.x versions exist at all